### PR TITLE
Allow passthrough of additional args in reply method

### DIFF
--- a/lib/Telegram/Bot/Object/Message.pm
+++ b/lib/Telegram/Bot/Object/Message.pm
@@ -149,7 +149,7 @@ sub reply {
   my $text = shift;
   my $args = shift // {};
 
-  return $self->_brain->sendMessage({chat_id => $self->chat->id, text => $text, $args->%* });
+  return $self->_brain->sendMessage({chat_id => $self->chat->id, text => $text, %$args });
 }
 
 1;

--- a/lib/Telegram/Bot/Object/Message.pm
+++ b/lib/Telegram/Bot/Object/Message.pm
@@ -147,7 +147,9 @@ sent.
 sub reply {
   my $self = shift;
   my $text = shift;
-  return $self->_brain->sendMessage({chat_id => $self->chat->id, text => $text});
+  my $args = shift // {};
+
+  return $self->_brain->sendMessage({chat_id => $self->chat->id, text => $text, $args->%* });
 }
 
 1;


### PR DESCRIPTION
Rather than adding specific wrappers for parse_mode values, just pass the same args right on through?