### PR TITLE
Add a github workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,144 @@
+
+---
+name: dzil build and test
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build-job:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:5.38
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Tests
+        env:
+          AUTHOR_TESTING: 1
+          AUTOMATED_TESTING: 1
+          EXTENDED_TESTING: 1
+          RELEASE_TESTING: 1
+        run: upgrade-perl-helpers && auto-build-and-test-dist
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build_dir
+          path: build_dir
+  coverage-job:
+    name: Coverage
+    needs: build-job
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:5.38
+    steps:
+      - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
+      - uses: actions/download-artifact@v3
+        with:
+          name: build_dir
+          path: .
+      - name: Install deps and test
+        run: cpan-install-dist-deps --with-develop && test-dist
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+  test-linux:
+    name: "${{ matrix.perl-version }} on Linux"
+    needs: build-job
+    runs-on: ubuntu-latest
+    container:
+      image: "perldocker/perl-tester:${{ matrix.perl-version }}"
+    strategy:
+      matrix:
+        perl-version:
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+          - "5.34"
+          - "5.36"
+          - "5.38"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: build_dir
+          path: .
+      - name: Install deps and test
+        run: cpan-install-dist-deps && test-dist
+  test-macos:
+    name: ${{ matrix.perl-version }} on macos-latest
+    needs: test-linux
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        perl-version:
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+          - "5.34"
+          - "5.36"
+          - "5.38"
+    steps:
+      - name: Set Up Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpanm@stable
+        with:
+          args: "--installdeps --with-recommends --with-develop ."
+      - run: prove -lr t
+  test-windows:
+    name: ${{ matrix.perl-version }} on windows-latest
+    needs: test-linux
+    runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        perl-version:
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+          - "5.36"
+          - "5.38"
+    steps:
+      - name: Set Up Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+          distribution: strawberry # this option only used on Windows
+      - uses: actions/download-artifact@v3
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpanm@stable
+        with:
+          args: "--installdeps --with-recommends --with-develop ."
+      - run: cpanm --test-only -v .

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    - reply method now passes additional args straight through to sendMessage
+    - enable automatic testing on every push, via GitHub Actions
+
 0.024     2023-10-10 12:41:52+01:00 Europe/London
 
     - sending messages now warns on errors, but never fails (kk12l) (GH#5)


### PR DESCRIPTION
Excludes perls older than 5.16 (minimum for the latest Mojo), needs new perl releases adding manually from time to time.