### PR TITLE
add support for inline queries

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@
 
     - add deleteMessage method for deleting messages
     - reply method now passes additional args straight through to sendMessage
+    - add support for inline mode
     - enable automatic testing on every push, via GitHub Actions
 
 0.024     2023-10-10 12:41:52+01:00 Europe/London

--- a/lib/Telegram/Bot/Brain.pm
+++ b/lib/Telegram/Bot/Brain.pm
@@ -63,6 +63,7 @@ use Log::Any;
 use Data::Dumper;
 
 use Telegram::Bot::Object::Message;
+use Telegram::Bot::Object::InlineQuery;
 
 # base class for building telegram robots with Mojolicious
 has longpoll_time => 60;
@@ -403,6 +404,75 @@ sub sendDocument {
   return Telegram::Bot::Object::Message->create_from_hash($api_response, $self);
 }
 
+=head2 answerInlineQuery
+
+Use this method to send answers to an inline query. On success, True is returned.
+No more than 50 results per query are allowed.
+
+See L<https://core.telegram.org/bots/api#answerinlinequery>.
+
+Takes an argument hash C<$args> with the following values.
+
+=over
+
+=item C<inline_query_id>
+
+Required. Unique identifier for the answered query. You get that 
+from the incoming L<Telegram::Bot::Object::InlineQuery>.
+
+=item C<results>
+
+Required. A JSON-serialized array of results for the inline query.
+You need to pass in a string of JSON.
+
+See L<https://core.telegram.org/bots/api#inlinequeryresult> for the format
+of the response.
+
+=item C<cache_time>
+
+Optional. The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
+
+=item C<is_personal>
+
+Optional. Pass True if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query.
+
+=item C<next_offset>
+
+Optional. Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don't support pagination. Offset length can't exceed 64 bytes.
+
+=item C<button>
+
+Optional. A JSON-serialized object describing a button to be shown above inline query results.
+
+=back
+
+See L<Telegram::Bot::Object::InlineQuery/reply> for a more convenient way to use this.
+
+=cut
+
+sub answerInlineQuery {
+  my $self = shift;
+  my $args = shift || {};
+  my $send_args = {};
+
+  croak "no inline_query_id supplied" unless $args->{inline_query_id};
+  $send_args->{inline_query_id} = $args->{inline_query_id};
+
+  croak "no results supplied" unless $args->{results};
+  $send_args->{results} = $args->{results};
+
+  # these are optional, send if they are supplied
+  $send_args->{cache_time} = $args->{cache_time} if exists $args->{cache_time};
+  $send_args->{is_personal} = $args->{is_personal} if exists $args->{is_personal};
+  $send_args->{next_offset} = $args->{next_offset} if exists $args->{next_offset};
+  $send_args->{button} = $args->{button} if exists $args->{button};
+
+  my $token = $self->token || croak "no token?";
+  my $url = "https://api.telegram.org/bot${token}/answerInlineQuery";
+  my $api_response = $self->_post_request($url, $send_args);
+
+  return $api_response;
+}
 
 sub _add_getUpdates_handler {
   my $self = shift;
@@ -451,6 +521,7 @@ sub _process_message {
     $update = Telegram::Bot::Object::Message->create_from_hash($item->{edited_message}, $self)      if $item->{edited_message};
     $update = Telegram::Bot::Object::Message->create_from_hash($item->{channel_post}, $self)        if $item->{channel_post};
     $update = Telegram::Bot::Object::Message->create_from_hash($item->{edited_channel_post}, $self) if $item->{edited_channel_post};
+    $update = Telegram::Bot::Object::InlineQuery->create_from_hash($item->{inline_query}, $self)    if $item->{inline_query};
 
     # if we got to this point without creating a response, it must be a type we
     # don't handle yet

--- a/lib/Telegram/Bot/Object/InlineQuery.pm
+++ b/lib/Telegram/Bot/Object/InlineQuery.pm
@@ -1,0 +1,88 @@
+package Telegram::Bot::Object::InlineQuery;
+
+# ABSTRACT: The base class for Telegram 'Invoice' type objects
+
+=head1 DESCRIPTION
+
+See L<https://core.telegram.org/bots/api#inlinequery> for details of the
+attributes available for L<Telegram::Bot::Object::InlineQuery> objects.
+
+=cut
+
+use Mojo::Base 'Telegram::Bot::Object::Base';
+use Mojo::JSON ();
+use Telegram::Bot::Object::Location;
+use Telegram::Bot::Object::User;
+
+has 'id';
+has 'from';        # User
+has 'query';
+has 'offset';
+has 'chat_type';
+has 'location';    # Location
+
+sub fields {
+    return {
+        scalar                            => [qw/id query offset chat_type/],
+        'Telegram::Bot::Object::User'     => [qw/from/],
+        'Telegram::Bot::Object::Location' => [qw/location/],
+    };
+}
+
+=method
+
+A convenience method to reply to an inline query with an array of Perl objects.
+
+Takes two arguments:
+
+=over
+
+=item C<$results>
+
+An optional array reference of results. Defaults to the empty array ref. See L<https://core.telegram.org/bots/api#inlinequeryresult>.
+
+=item C<$args>
+
+An optional hash references of optional arguments.
+
+=over
+
+=item C<cache_time>
+
+The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300 if not present.
+
+=item C<is_personal>
+
+Pass True if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query.
+
+=item C<next_offset>
+
+Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don't support pagination. Offset length can't exceed 64 bytes.
+
+=item C<button>
+
+A JSON-serialized object describing a button to be shown above inline query results
+
+=over
+
+=over
+
+Will return true.
+
+=cut
+
+sub reply {
+    my $self    = shift;
+    my $results = shift // [];
+    my $args    = shift // {};
+
+    return $self->_brain->answerInlineQuery(
+        {
+            inline_query_id => $self->id,
+            results         => Mojo::JSON::encode_json($results),
+            %$args
+        }
+    );
+}
+
+1;

--- a/lib/Telegram/Bot/Object/Message.pm
+++ b/lib/Telegram/Bot/Object/Message.pm
@@ -34,6 +34,7 @@ use Telegram::Bot::Object::SuccessfulPayment;
 use Telegram::Bot::Object::PassportData;
 use Telegram::Bot::Object::InlineKeyboardMarkup;
 use Telegram::Bot::Object::ReplyKeyboardMarkup;
+use Telegram::Bot::Object::InlineQuery;
 
 use Data::Dumper;
 
@@ -89,6 +90,7 @@ has 'successful_payment'; # SuccessfulPayment
 has 'connected_website';
 has 'passport_data'; # PassportData
 has 'reply_markup'; # Array of InlineKeyboardMarkup/ReplyKeyboardMarkup
+has 'inline_query'; # InlineQuery
 
 sub fields {
   return {
@@ -127,6 +129,7 @@ sub fields {
           'Telegram::Bot::Object::PassportData'         => [qw/passport_data/],
           'Telegram::Bot::Object::InlineKeyboardMarkup' => [qw/reply_markup/],
           'Telegram::Bot::Object::ReplyKeyboardMarkup'  => [qw/reply_markup/],
+          'Telegram::Bot::Object::InlineQuery'          => [qw/inline_query/],
 
   };
 }

--- a/t/04-message-inline_query.t
+++ b/t/04-message-inline_query.t
@@ -1,0 +1,37 @@
+use Test::More;
+use Test::Exception;
+
+my $msg = {
+    'chat_type' => "group",
+    'from'      => {
+        'first_name'    => "Bob",
+        'id'            => 1234,
+        'language_code' => "en",
+        'last_name'     => "",
+        'username'      => "Bob",
+    },
+    'id'       => 123,
+    'offset'   => "",
+    'query'    => "foo",
+    'location' => {
+        'longitude' => '138.7',
+        'latitude'  => '-34.8'
+    },
+
+};
+
+use_ok('Telegram::Bot::Object::InlineQuery');
+
+my $fake_brain = {};
+bless $fake_brain, 'Telegram::Bot::Brain';
+my $msg1 =
+  Telegram::Bot::Object::InlineQuery->create_from_hash( $msg, $fake_brain );
+
+ok( defined $msg1->query );
+is( $msg1->query,               'foo' );
+is( $msg1->from->first_name,    'Bob' );
+is( $msg1->chat_type,           'group' );
+is( $msg1->id,                  123 );
+is( $msg1->location->longitude, '138.7' );
+
+done_testing();


### PR DESCRIPTION
This commit adds support for receiving `InlineQuery` messages from Telegram and let us respond to them with `answerInlineQuery`. There are however some limitations.

We do not add support for `ChosenInlineResult` at this point, so there also no classes for all the different types of `InlineResult`. This means we do not support turning on "inline feedback" via BotFather. We also don't support WebApps, so all the functionality relating to this has not been implemented for inline queries.